### PR TITLE
Update main function to parse command-line flags

### DIFF
--- a/app.go
+++ b/app.go
@@ -18,6 +18,9 @@ var (
 )
 
 func main() {
+	// Parse command-line flags
+	flag.Parse()
+
 	// Connected with database
 	database.Connect()
 


### PR DESCRIPTION
At the moment, the main function does not parse command-line flags. This PR fixes that.