### PR TITLE
fix: fix typo test workflow name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - master
   pull_request:
-name: Tests
+name: Test
 jobs:
   Tests:
     strategy:


### PR DESCRIPTION
Hi, thank you for providing useful boilerplate
There seems to be an typo error in the README.md where the test badge is shown as no status or not visible because the name of the test workflow is Tests. So I fixed it with Test


Also it is possible to change the readme with Tests like `![Test](https://github.com/gofiber/boilerplate/workflows/Tests/badge.svg)`. But I think it would be better to change workflow name with "Test" for unity